### PR TITLE
Expose DefaultExternalServiceMetricsTracker

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const { Metrics } = require('./lib/metrics');
-const { ExpressMiddlewareDefaultSettings } = require('./lib/constants');
+const { ExpressMiddlewareDefaultSettings, ExternalServiceConstants } = require('./lib/constants');
 const { MetricsTracker } = require('./lib/metrics-tracker');
+const { DefaultExternalServiceMetricsTracker } = require('./lib/external-service-metrics-tracker');
 
 module.exports = {
     Metrics,
     ExpressMiddlewareDefaultSettings,
-    MetricsTracker
+    MetricsTracker,
+    ExternalServiceConstants,
+    DefaultExternalServiceMetricsTracker
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Metrics } = require('./lib/metrics');
-const { ExpressMiddlewareDefaultSettings, ExternalServiceConstants } = require('./lib/constants');
+const { ExpressMiddlewareDefaultSettings } = require('./lib/constants');
 const { MetricsTracker } = require('./lib/metrics-tracker');
 const { ExternalServiceMetricsTracker } = require('./lib/external-service-metrics-tracker');
 
@@ -9,6 +9,5 @@ module.exports = {
     Metrics,
     ExpressMiddlewareDefaultSettings,
     MetricsTracker,
-    ExternalServiceConstants,
     ExternalServiceMetricsTracker
 };

--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 const { Metrics } = require('./lib/metrics');
 const { ExpressMiddlewareDefaultSettings, ExternalServiceConstants } = require('./lib/constants');
 const { MetricsTracker } = require('./lib/metrics-tracker');
-const { DefaultExternalServiceMetricsTracker } = require('./lib/external-service-metrics-tracker');
+const { ExternalServiceMetricsTracker } = require('./lib/external-service-metrics-tracker');
 
 module.exports = {
     Metrics,
     ExpressMiddlewareDefaultSettings,
     MetricsTracker,
     ExternalServiceConstants,
-    DefaultExternalServiceMetricsTracker
+    ExternalServiceMetricsTracker
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,8 +23,20 @@ const Labels = {
     Error: 'error'
 };
 
+const ExternalServiceConstants = {
+    Name: 'external_service_request_duration_seconds',
+    Labels: {
+        Target: 'target',
+        Error: 'error'
+    },
+    HistogramValues: {
+        Bucket: [0.1, 0.3, 1.5, 5, 10, 15, 20, 30]
+    }
+};
+
 module.exports = {
     ExpressMiddlewareDefaultSettings,
     DefaultBackendSettings,
-    Labels
+    Labels,
+    ExternalServiceConstants
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,7 +23,7 @@ const Labels = {
     Error: 'error'
 };
 
-const ExternalServiceConstants = {
+const ExternalServiceMetricConstants = {
     Name: 'external_service_request_duration_seconds',
     Labels: {
         Target: 'target',
@@ -38,5 +38,5 @@ module.exports = {
     ExpressMiddlewareDefaultSettings,
     DefaultBackendSettings,
     Labels,
-    ExternalServiceConstants
+    ExternalServiceMetricConstants
 };

--- a/lib/external-service-metrics-tracker.js
+++ b/lib/external-service-metrics-tracker.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { ExternalServiceConstants } = require('./constants');
+const { MetricsTracker } = require('./metrics-tracker');
+
+class DefaultExternalServiceMetricsTracker {
+    constructor({ promClient }) {
+        if (!promClient) {
+            throw new Error('promClient argument is mandatory.');
+        }
+
+        const externalServiceLabels = Object.values(ExternalServiceConstants.Labels);
+        const metrics = {
+            [ExternalServiceConstants.Name]: new promClient.Histogram({
+                name: ExternalServiceConstants.Name,
+                help: `duration histogram of external service calls labeled with: ${externalServiceLabels.join(', ')}`,
+                labelNames: externalServiceLabels,
+                buckets: ExternalServiceConstants.HistogramValues.Bucket
+            }),
+        };
+
+        this.metricsTracker = new MetricsTracker({ metrics });
+    }
+
+    trackHistogramDuration({ targetLabel, action, handleResult }) {
+        return this.metricsTracker.trackHistogramDuration({
+            metricName: ExternalServiceConstants.Name,
+            labels: {
+                [ExternalServiceConstants.Labels.Target]: targetLabel
+            },
+            action,
+            handleResult
+        });
+    }
+}
+
+module.exports = { DefaultExternalServiceMetricsTracker };

--- a/lib/external-service-metrics-tracker.js
+++ b/lib/external-service-metrics-tracker.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ExternalServiceConstants } = require('./constants');
+const { ExternalServiceMetricConstants } = require('./constants');
 const { MetricsTracker } = require('./metrics-tracker');
 
 class ExternalServiceMetricsTracker {
@@ -9,24 +9,24 @@ class ExternalServiceMetricsTracker {
             throw new Error('promClient argument is mandatory.');
         }
 
-        const externalServiceLabels = Object.values(ExternalServiceConstants.Labels);
+        const externalServiceLabels = Object.values(ExternalServiceMetricConstants.Labels);
         const metrics = {
-            [ExternalServiceConstants.Name]: new promClient.Histogram({
-                name: ExternalServiceConstants.Name,
+            [ExternalServiceMetricConstants.Name]: new promClient.Histogram({
+                name: ExternalServiceMetricConstants.Name,
                 help: `duration histogram of external service calls labeled with: ${externalServiceLabels.join(', ')}`,
                 labelNames: externalServiceLabels,
-                buckets: ExternalServiceConstants.HistogramValues.Bucket
+                buckets: ExternalServiceMetricConstants.HistogramValues.Bucket
             }),
         };
 
-        this.metricsTracker = new MetricsTracker({ metrics });
+        this._metricsTracker = new MetricsTracker({ metrics });
     }
 
     trackHistogramDuration({ targetLabel, action, handleResult }) {
-        return this.metricsTracker.trackHistogramDuration({
-            metricName: ExternalServiceConstants.Name,
+        return this._metricsTracker.trackHistogramDuration({
+            metricName: ExternalServiceMetricConstants.Name,
             labels: {
-                [ExternalServiceConstants.Labels.Target]: targetLabel
+                [ExternalServiceMetricConstants.Labels.Target]: targetLabel
             },
             action,
             handleResult

--- a/lib/external-service-metrics-tracker.js
+++ b/lib/external-service-metrics-tracker.js
@@ -3,7 +3,7 @@
 const { ExternalServiceConstants } = require('./constants');
 const { MetricsTracker } = require('./metrics-tracker');
 
-class DefaultExternalServiceMetricsTracker {
+class ExternalServiceMetricsTracker {
     constructor({ promClient }) {
         if (!promClient) {
             throw new Error('promClient argument is mandatory.');
@@ -34,4 +34,4 @@ class DefaultExternalServiceMetricsTracker {
     }
 }
 
-module.exports = { DefaultExternalServiceMetricsTracker };
+module.exports = { ExternalServiceMetricsTracker };

--- a/lib/metrics-tracker.js
+++ b/lib/metrics-tracker.js
@@ -31,7 +31,7 @@ class MetricsTracker {
 
             return result;
         } catch (err) {
-            labels[Labels.Error] = err.name || err.code;
+            labels[Labels.Error] = err.name || err.type || err.code;
             timer();
 
             throw err;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-metrics",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Module which provides metrics server for NodeJS applications.",
   "main": "index.js",
   "scripts": {

--- a/spec/constants.js
+++ b/spec/constants.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const DefaultMetricsServerPort = 39110;
+
+module.exports = {
+    DefaultMetricsServerPort
+};

--- a/spec/helpers/helpers.js
+++ b/spec/helpers/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const http = require('http');
+const { DefaultMetricsServerPort } = require('../constants');
 
 const httpGet = async (url) => {
     const metricsResult = await new Promise((resolve, reject) => {
@@ -17,7 +18,7 @@ const httpGet = async (url) => {
     return metricsResult;
 };
 
-const verifyMetricsResponse = async (expectedMetrics, port) => {
+const verifyMetricsResponse = async (expectedMetrics, port = DefaultMetricsServerPort) => {
     const metricsResponse = await httpGet(`http://localhost:${port}/metrics`);
 
     expectedMetrics.forEach((expectedMetric) => {

--- a/spec/integration/external-service-metrics-tracker.spec.js
+++ b/spec/integration/external-service-metrics-tracker.spec.js
@@ -2,9 +2,9 @@
 
 const { verifyMetricsResponse } = require('../helpers/helpers');
 
-const { DefaultExternalServiceMetricsTracker, Metrics } = require('../../index');
+const { ExternalServiceMetricsTracker, Metrics } = require('../../index');
 
-describe('DefaultExternalServiceMetricsTracker', () => {
+describe('ExternalServiceMetricsTracker', () => {
     let metrics;
 
     beforeEach(async () => {
@@ -16,19 +16,19 @@ describe('DefaultExternalServiceMetricsTracker', () => {
         await metrics.destroy();
     });
 
-    it('should return error if no promClient is passed.', () => {
-        expect(() => { new DefaultExternalServiceMetricsTracker({}); }).toThrowError('promClient argument is mandatory.');
+    it('should throw error if no promClient is passed.', () => {
+        expect(() => { new ExternalServiceMetricsTracker({}); }).toThrowError('promClient argument is mandatory.');
     });
 
     it('should throw if instantiated multiple times with the same promClient.', () => {
         const promClient = metrics.getClient();
-        new DefaultExternalServiceMetricsTracker({ promClient });
-        expect(() => { new DefaultExternalServiceMetricsTracker({ promClient }); }).toThrowError('A metric with the name external_service_request_duration_seconds has already been registered.');
+        new ExternalServiceMetricsTracker({ promClient });
+        expect(() => { new ExternalServiceMetricsTracker({ promClient }); }).toThrowError('A metric with the name external_service_request_duration_seconds has already been registered.');
     });
 
     it('returned tracker should track histogram metrics.', async () => {
         const promClient = metrics.getClient();
-        const tracker = new DefaultExternalServiceMetricsTracker({ promClient });
+        const tracker = new ExternalServiceMetricsTracker({ promClient });
 
         const baseOptions = {
             targetLabel: 'test_label'

--- a/spec/integration/external-service-metrics-tracker.spec.js
+++ b/spec/integration/external-service-metrics-tracker.spec.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { verifyMetricsResponse } = require('../helpers/helpers');
+
+const { DefaultExternalServiceMetricsTracker, Metrics } = require('../../index');
+
+describe('DefaultExternalServiceMetricsTracker', () => {
+    let metrics;
+
+    beforeEach(async () => {
+        metrics = new Metrics();
+        await metrics.init();
+    });
+
+    afterEach(async () => {
+        await metrics.destroy();
+    });
+
+    it('should return error if no promClient is passed.', () => {
+        expect(() => { new DefaultExternalServiceMetricsTracker({}); }).toThrowError('promClient argument is mandatory.');
+    });
+
+    it('should throw if instantiated multiple times with the same promClient.', () => {
+        const promClient = metrics.getClient();
+        new DefaultExternalServiceMetricsTracker({ promClient });
+        expect(() => { new DefaultExternalServiceMetricsTracker({ promClient }); }).toThrowError('A metric with the name external_service_request_duration_seconds has already been registered.');
+    });
+
+    it('returned tracker should track histogram metrics.', async () => {
+        const promClient = metrics.getClient();
+        const tracker = new DefaultExternalServiceMetricsTracker({ promClient });
+
+        const baseOptions = {
+            targetLabel: 'test_label'
+        };
+
+        await tracker.trackHistogramDuration(Object.assign(baseOptions, { action: async () => { } }));
+
+        await expectAsync(tracker.trackHistogramDuration(Object.assign(baseOptions, {
+            action: async () => {
+                const err = new Error();
+                err.name = 'TestErr';
+
+                throw err;
+            }
+        }))).toBeRejected();
+
+        await verifyMetricsResponse([
+            '# HELP external_service_request_duration_seconds duration histogram of external service calls labeled with: target, error',
+            '# TYPE external_service_request_duration_seconds histogram',
+            'external_service_request_duration_seconds_bucket{le="0.1",target="test_label"} 1',
+            'external_service_request_duration_seconds_bucket{le="0.3",target="test_label"} 1',
+            'external_service_request_duration_seconds_bucket{le="1.5",target="test_label"} 1',
+            'external_service_request_duration_seconds_bucket{le="5",target="test_label"} 1',
+            'external_service_request_duration_seconds_bucket{le="10",target="test_label"} 1',
+            'external_service_request_duration_seconds_bucket{le="15",target="test_label"} 1',
+            'external_service_request_duration_seconds_bucket{le="20",target="test_label"} 1',
+            'external_service_request_duration_seconds_bucket{le="30",target="test_label"} 1',
+            'external_service_request_duration_seconds_bucket{le="+Inf",target="test_label"} 1',
+            'external_service_request_duration_seconds_sum{target="test_label"}',
+            'external_service_request_duration_seconds_count{target="test_label"} 1',
+            'external_service_request_duration_seconds_bucket{le="0.1",target="test_label",error="TestErr"} 1',
+            'external_service_request_duration_seconds_bucket{le="0.3",target="test_label",error="TestErr"} 1',
+            'external_service_request_duration_seconds_bucket{le="1.5",target="test_label",error="TestErr"} 1',
+            'external_service_request_duration_seconds_bucket{le="5",target="test_label",error="TestErr"} 1',
+            'external_service_request_duration_seconds_bucket{le="10",target="test_label",error="TestErr"} 1',
+            'external_service_request_duration_seconds_bucket{le="15",target="test_label",error="TestErr"} 1',
+            'external_service_request_duration_seconds_bucket{le="20",target="test_label",error="TestErr"} 1',
+            'external_service_request_duration_seconds_bucket{le="30",target="test_label",error="TestErr"} 1',
+            'external_service_request_duration_seconds_bucket{le="+Inf",target="test_label",error="TestErr"} 1',
+            'external_service_request_duration_seconds_sum{target="test_label",error="TestErr"}',
+            'external_service_request_duration_seconds_count{target="test_label",error="TestErr"} 1'
+        ]);
+    });
+});

--- a/spec/integration/metrics-tracker.spec.js
+++ b/spec/integration/metrics-tracker.spec.js
@@ -4,8 +4,6 @@ const { verifyMetricsResponse } = require('../helpers/helpers');
 
 const { Metrics, MetricsTracker } = require('../../index');
 
-const DefaultMetricsServerPort = 39110;
-
 describe('MetricsTracker', () => {
     let metrics;
 
@@ -78,7 +76,7 @@ describe('MetricsTracker', () => {
                 'test_bucket{le="+Inf",foo="bar",error="TestErr"} 1',
                 'test_sum{foo="bar",error="TestErr"}',
                 'test_count{foo="bar",error="TestErr"} 1'
-            ], DefaultMetricsServerPort);
+            ]);
         });
 
         it('should track counter metrics.', async () => {
@@ -102,7 +100,7 @@ describe('MetricsTracker', () => {
                 '# HELP test some help',
                 '# TYPE test counter',
                 'test{foo="bar"} 1'
-            ], DefaultMetricsServerPort);
+            ]);
         });
     });
 });

--- a/spec/integration/metrics.spec.js
+++ b/spec/integration/metrics.spec.js
@@ -4,9 +4,9 @@ const express = require('express');
 
 const { httpGet, verifyMetricsResponse } = require('../helpers/helpers');
 
-const { Metrics } = require('../../index');
+const { DefaultMetricsServerPort } = require('../constants');
 
-const DefaultMetricsServerPort = 39110;
+const { Metrics } = require('../../index');
 
 const DefaultNodeJSMetrics = [
     '# TYPE process_cpu_user_seconds_total counter',
@@ -40,7 +40,7 @@ describe('Metrics', () => {
 
     describe('Server', () => {
         it('should return default nodejs and http metrics.', async () => {
-            await verifyMetricsResponse(DefaultNodeJSMetrics, DefaultMetricsServerPort);
+            await verifyMetricsResponse(DefaultNodeJSMetrics);
         });
 
         it('should return express req/res metrics.', async () => {
@@ -72,7 +72,7 @@ describe('Metrics', () => {
                 'http_request_duration_seconds_count{status_code="404",method="GET",path="/__notFound__"} 1'
             ];
 
-            await verifyMetricsResponse(expectedMetrics, DefaultMetricsServerPort);
+            await verifyMetricsResponse(expectedMetrics);
         });
 
         it('should start the server on a new port if the default one is busy.', async () => {


### PR DESCRIPTION
Will be used in `darvin` for Rekognition and `darvin-nlp` for Bing Translate