### PR TITLE
Add error to the handleresult callback

### DIFF
--- a/lib/metrics-tracker.ts
+++ b/lib/metrics-tracker.ts
@@ -27,14 +27,17 @@ export class MetricsTracker implements IMetricsTracker {
         try {
             const result = await action();
             if (handleResult) {
-                handleResult(result, labels);
+                handleResult(null, labels, result);
             }
 
             timer();
 
             return result;
         } catch (err) {
-            labels[Labels.Error] = err.name || err.type || err.code;
+            if (handleResult) {
+                handleResult(err, labels);
+            }
+
             timer();
 
             throw err;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -55,7 +55,7 @@ export interface IMetricsClient {
 
 export interface IHistogramActionComposition<T> {
     action: () => Promise<T>;
-    handleResult?: (result: T, labels: IDictionary<string>) => void;
+    handleResult?: (err: any | null, labels: IDictionary<string>, result?: T) => void;
 }
 
 export interface ILabelsComposition {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-metrics",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-metrics",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Module which provides metrics server for NodeJS applications.",
   "main": "index.js",
   "types": "./index",


### PR DESCRIPTION
This way we can add additional labels when the execution of the action throws an error.